### PR TITLE
Removing Oraclejdk7 as installer no longer supported and Adding ppc64le architecture to support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,10 @@ language: java
 jdk:
   - openjdk8
   - openjdk11
+before_install:
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then mkdir -p /opt/maven; curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz|tar -xz --strip 1 -C /opt/maven; export MAVEN_HOME=/opt/maven; export PATH=${MAVEN_HOME}/bin:${PATH}; fi
+
+arch:
+  - ppc64le
+  - amd64
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
-  - oraclejdk7
   - openjdk8
   - openjdk11


### PR DESCRIPTION
Hi,
I had removed oraclejdk7 as installer no longer supports the version . It looks like Oraclejdk7 successfully removed. I believe it is ready for the final review and merge.

The travis-ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/uom-parent/builds/183708164
https://www.travis-ci.com/github/kishorkunal-raj/uom-parent/builds/183709641

Reference: https://github.com/travis-ci/travis-ci/issues/7964
                  http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html
Please have a look.

Thanks!!"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/uom-parent/23)
<!-- Reviewable:end -->
